### PR TITLE
Adds a helm chart, dockerfile, and instructions for running examples with Kubernetes

### DIFF
--- a/examples/kubernetes/Chart.yaml
+++ b/examples/kubernetes/Chart.yaml
@@ -21,4 +21,5 @@ version: 0.1.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.11.1"
+appVersion: "1.12.0"
+

--- a/examples/kubernetes/Chart.yaml
+++ b/examples/kubernetes/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: Deploy Optimum for Intel® Gaudi® Accelerators Examples to Kubernetes
+description: This Helm chart deploys example jobs using Optimum for Intel® Gaudi® Accelerators to a Kubernetes cluster.
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.11.1"

--- a/examples/kubernetes/Dockerfile
+++ b/examples/kubernetes/Dockerfile
@@ -1,17 +1,18 @@
 ARG BASE_IMAGE_NAME=vault.habana.ai/gaudi-docker/1.15.1/ubuntu22.04/habanalabs/pytorch-installer-2.2.0
+ARG BASE_IMAGE_NAME=vault.habana.ai/gaudi-docker/1.16.1/ubuntu22.04/habanalabs/pytorch-installer-2.2.2
 ARG BASE_IMAGE_TAG=latest
 
 FROM ${BASE_IMAGE_NAME}:${BASE_IMAGE_TAG} AS optimum-habana
 
-ARG GAUDI_SW_VER=1.15.1
-ARG OPTIMUM_HABANA_VER=1.11.1
+ARG GAUDI_SW_VER=1.16.1
+ARG OPTIMUM_HABANA_VER=1.12.0
 
 RUN pip install --no-cache-dir optimum-habana==${OPTIMUM_HABANA_VER} && \
     pip install --no-cache-dir git+https://github.com/HabanaAI/DeepSpeed.git@${GAUDI_SW_VER}
 
 FROM optimum-habana AS optimum-habana-examples
 
-ARG OPTIMUM_HABANA_VER=1.11.1
+ARG OPTIMUM_HABANA_VER=1.12.0
 
 WORKDIR /workspace
 

--- a/examples/kubernetes/Dockerfile
+++ b/examples/kubernetes/Dockerfile
@@ -1,4 +1,3 @@
-ARG BASE_IMAGE_NAME=vault.habana.ai/gaudi-docker/1.15.1/ubuntu22.04/habanalabs/pytorch-installer-2.2.0
 ARG BASE_IMAGE_NAME=vault.habana.ai/gaudi-docker/1.16.1/ubuntu22.04/habanalabs/pytorch-installer-2.2.2
 ARG BASE_IMAGE_TAG=latest
 

--- a/examples/kubernetes/Dockerfile
+++ b/examples/kubernetes/Dockerfile
@@ -1,0 +1,21 @@
+ARG BASE_IMAGE_NAME=vault.habana.ai/gaudi-docker/1.15.1/ubuntu22.04/habanalabs/pytorch-installer-2.2.0
+ARG BASE_IMAGE_TAG=latest
+
+FROM ${BASE_IMAGE_NAME}:${BASE_IMAGE_TAG} AS optimum-habana
+
+ARG GAUDI_SW_VER=1.15.1
+ARG OPTIMUM_HABANA_VER=1.11.1
+
+RUN pip install --no-cache-dir optimum-habana==${OPTIMUM_HABANA_VER} && \
+    pip install --no-cache-dir git+https://github.com/HabanaAI/DeepSpeed.git@${GAUDI_SW_VER}
+
+FROM optimum-habana AS optimum-habana-examples
+
+ARG OPTIMUM_HABANA_VER=1.11.1
+
+WORKDIR /workspace
+
+RUN git clone https://github.com/huggingface/optimum-habana.git --single-branch --branch v${OPTIMUM_HABANA_VER}
+
+COPY requirements.txt .
+RUN pip install -r requirements.txt

--- a/examples/kubernetes/README.md
+++ b/examples/kubernetes/README.md
@@ -105,7 +105,7 @@ your job, the name and tag of your Docker image, the number of HPU cards to use 
 | resources.requests.memory | string | `"128Gi"` | Specify [memory resource](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#meaning-of-memory) requests for the job |
 | secret.encodedToken | string | `nil` | Hugging Face token encoded using base64. |
 | secret.secretMountPath | string | `"/tmp/hf_token"` | If a token is provided, specify a mount path that will be used to set HF_TOKEN_PATH |
-| securityContext.privileged | bool | `true` | Run as privileged or unprivileged |
+| securityContext.privileged | bool | `false` | Run as privileged or unprivileged. Certain deployments may require running as privileged, check with your system admin. |
 | storage.accessModes | list | `["ReadWriteMany"]` | [Access modes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes) for the persistent volume. |
 | storage.deployDataAccessPod | bool | `true` | A data access pod will be deployed when set to true. This allows accessing the data from the PVC after the worker pod has completed. |
 | storage.pvcMountPath | string | `"/tmp/pvc-mount"` | Locaton where the PVC will be mounted in the pod |

--- a/examples/kubernetes/README.md
+++ b/examples/kubernetes/README.md
@@ -63,7 +63,7 @@ docker push <image name>:<tag>
 ### Kubernetes resources
 
 This Kubernetes job uses a [Helm chart](https://helm.sh) with the following resources:
-* Job to run the Optimum Habana example script using HPU(s)
+* Job to run the Optimum Habana example script using HPU(s) from a single node
 * [Persistant volume claim](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#persistentvolumeclaims)
   (PVC) backed by NFS to store output files
 * (Optional) Pod used to access the files from the PVC after the worker pod completes
@@ -125,9 +125,9 @@ Validated use cases can be found in the `ci` directory:
 | Values files path | HPUs | Description |
 |-------------------|------|-------------|
 | [`ci/single-card-glue-values.yaml`](ci/single-card-glue-values.yaml) | 1 | Uses a single card to [fine tune BERT large](../text-classification/README.md#single-card-training) (with whole word masking) on the text classification MRPC task using `run_glue.py`.
-| [`ci/multi-card-glue-values.yaml`](ci/multi-card-glue-values.yaml) | 2 | Uses 2 HPUs with the [`gaudi_spawn.py`](../gaudi_spawn.py) script to [fine tune BERT large](../text-classification/README.md#multi-card-training) (with whole word masking) on the text classification MRPC task using `run_glue.py`.
+| [`ci/multi-card-glue-values.yaml`](ci/multi-card-glue-values.yaml) | 2 | Uses 2 HPUs from a single node with the [`gaudi_spawn.py`](../gaudi_spawn.py) script to [fine tune BERT large](../text-classification/README.md#multi-card-training) (with whole word masking) on the text classification MRPC task using `run_glue.py`.
 | [`ci/single-card-lora-clm-values.yaml`](ci/single-card-lora-clm-values.yaml) | 1 | Uses a single card to [fine tune Llama1-7B](../language-modeling/README.md#peft) with LoRA using the `run_lora_clm.py` script.
-| [`ci/multi-card-lora-clm-values.yaml`](ci/multi-card-lora-clm-values.yaml) | 8 | Uses 8 HPUs with the [`gaudi_spawn.py`](../gaudi_spawn.py) script to [fine tune Llama1-7B](../language-modeling/README.md#peft) with LoRA using the `run_lora_clm.py` script.
+| [`ci/multi-card-lora-clm-values.yaml`](ci/multi-card-lora-clm-values.yaml) | 8 | Uses 8 HPUs from a single node with the [`gaudi_spawn.py`](../gaudi_spawn.py) script to [fine tune Llama1-7B](../language-modeling/README.md#peft) with LoRA using the `run_lora_clm.py` script.
 
 ### Deploy job to the cluster
 

--- a/examples/kubernetes/README.md
+++ b/examples/kubernetes/README.md
@@ -35,14 +35,14 @@ Use the the following commands to build the containers:
 
 ```bash
 # Specify the base image name/tag
-export BASE_IMAGE_NAME=vault.habana.ai/gaudi-docker/1.15.1/ubuntu22.04/habanalabs/pytorch-installer-2.2.0
+export BASE_IMAGE_NAME=vault.habana.ai/gaudi-docker/1.16.1/ubuntu22.04/habanalabs/pytorch-installer-2.2.2
 export BASE_IMAGE_TAG=latest
 
 # Specify your Gaudi Software version and Optimum Habana version
-export GAUDI_SW_VER=1.15.1
-export OPTIMUM_HABANA_VER=1.11.1
+export GAUDI_SW_VER=1.16.1
+export OPTIMUM_HABANA_VER=1.12.0
 
-git clone https://github.com/huggingface/optimum-habana.git --single-branch --branch v${OPTIMUM_HABANA_VER}
+git clone https://github.com/huggingface/optimum-habana.git
 
 # Note: Modify the requirements.txt file in the kubernetes directory for the specific example(s) that you want to run
 cd optimum-habana/examples/kubernetes

--- a/examples/kubernetes/README.md
+++ b/examples/kubernetes/README.md
@@ -1,6 +1,6 @@
 # Deploy Optimum for Intel® Gaudi® Accelerators Examples to Kubernetes
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.11.1](https://img.shields.io/badge/AppVersion-1.11.1-informational?style=flat-square)
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.12.0](https://img.shields.io/badge/AppVersion-1.12.0-informational?style=flat-square)
 
 This folder contains a Dockerfile and [Helm chart](https://helm.sh) demonstrating how 🤗 Optimum Habana examples
 can be run using Intel® Gaudi® AI accelerator nodes from a vanilla Kubernetes cluster. The instructions below

--- a/examples/kubernetes/README.md
+++ b/examples/kubernetes/README.md
@@ -2,7 +2,7 @@
 
 ![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.11.1](https://img.shields.io/badge/AppVersion-1.11.1-informational?style=flat-square)
 
-This folder contains a Dockerfile and [Helm chart](https://helm.sh) demonstrating how to run 🤗 Optimum Habana examples
+This folder contains a Dockerfile and [Helm chart](https://helm.sh) demonstrating how 🤗 Optimum Habana examples
 can be run using Intel® Gaudi® AI accelerator nodes from a vanilla Kubernetes cluster. The instructions below
 explain how to build the docker image and deploy the job to a Kubernetes cluster using Helm.
 
@@ -19,16 +19,17 @@ In order to build the docker images and deploy a job to Kubernetes you will need
 
 ### Cluster Requirements
 
-Your Kubernetes cluster will need the [Intel Gaudi Device Plugin for Kubernetes](https://docs.habana.ai/en/latest/Orchestration/Gaudi_Kubernetes/Device_Plugin_for_Kubernetes.html) in order to request and utilize the accelerators
-in the Kubernetes job. Also, ensure that your Kubernetes version is supported based on the
+Your Kubernetes cluster will need the [Intel Gaudi Device Plugin for Kubernetes](https://docs.habana.ai/en/latest/Orchestration/Gaudi_Kubernetes/Device_Plugin_for_Kubernetes.html)
+in order to request and utilize the accelerators in the Kubernetes job. Also, ensure that your Kubernetes version is supported based on the
 [support matrix](https://docs.habana.ai/en/latest/Support_Matrix/Support_Matrix.html#support-matrix).
 
 ## Container
 
-The [Dockerfile](Dockerfile) and [docker-compose.yaml](docker-compose.yaml) builds the following images:
+The [Dockerfile](Dockerfile) and [docker-compose.yaml](docker-compose.yaml) build the following images:
 
-* An `optimum-habana` base image that uses the [PyTorch Docker images for Gaudi](https://developer.habana.ai/catalog/pytorch-container/) as it's base, then installs optimum-habana and Deep Speed.
-* A `optimum-habana-examples` image is built on top of the `optimum-habana` base to includes installations from
+* An `optimum-habana` base image that uses the [PyTorch Docker images for Gaudi](https://developer.habana.ai/catalog/pytorch-container/) as it's base, and then installs
+optimum-habana and the Habana fork of Deep Speed.
+* An `optimum-habana-examples` image is built on top of the `optimum-habana` base to includes installations from
 `requirements.txt` files in the example directories and a clone of [this GitHub repository](https://github.com/huggingface/optimum-habana/) in order to run example scripts.
 
 Use the the following commands to build the containers:

--- a/examples/kubernetes/README.md
+++ b/examples/kubernetes/README.md
@@ -1,0 +1,173 @@
+# Deploy Optimum for Intel® Gaudi® Accelerators Examples to Kubernetes
+
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.11.1](https://img.shields.io/badge/AppVersion-1.11.1-informational?style=flat-square)
+
+This folder contains a Dockerfile and [Helm chart](https://helm.sh) demonstrating how to run 🤗 Optimum Habana examples
+can be run using Intel® Gaudi® AI accelerator nodes from a vanilla Kubernetes cluster. The instructions below
+explain how to build the docker image and deploy the job to a Kubernetes cluster using Helm.
+
+## Requirements
+
+### Client System Requirements
+
+In order to build the docker images and deploy a job to Kubernetes you will need:
+
+* [Docker](https://docs.docker.com/engine/install/)
+* [Docker compose](https://docs.docker.com/compose/install/)
+* [kubectl](https://kubernetes.io/docs/tasks/tools/) installed and configured to access a cluster
+* [Helm CLI](https://helm.sh/docs/intro/install/)
+
+### Cluster Requirements
+
+Your Kubernetes cluster will need the [Intel Gaudi Device Plugin for Kubernetes](https://docs.habana.ai/en/latest/Orchestration/Gaudi_Kubernetes/Device_Plugin_for_Kubernetes.html) in order to request and utilize the accelerators
+in the Kubernetes job. Also, ensure that your Kubernetes version is supported based on the
+[support matrix](https://docs.habana.ai/en/latest/Support_Matrix/Support_Matrix.html#support-matrix).
+
+## Container
+
+The [Dockerfile](Dockerfile) and [docker-compose.yaml](docker-compose.yaml) builds the following images:
+
+* An `optimum-habana` base image that uses the [PyTorch Docker images for Gaudi](https://developer.habana.ai/catalog/pytorch-container/) as it's base, then installs optimum-habana and Deep Speed.
+* A `optimum-habana-examples` image is built on top of the `optimum-habana` base to includes installations from
+`requirements.txt` files in the example directories and a clone of [this GitHub repository](https://github.com/huggingface/optimum-habana/) in order to run example scripts.
+
+Use the the following commands to build the containers:
+
+```bash
+# Specify the base image name/tag
+export BASE_IMAGE_NAME=vault.habana.ai/gaudi-docker/1.15.1/ubuntu22.04/habanalabs/pytorch-installer-2.2.0
+export BASE_IMAGE_TAG=latest
+
+# Specify your Gaudi Software version and Optimum Habana version
+export GAUDI_SW_VER=1.15.1
+export OPTIMUM_HABANA_VER=1.11.1
+
+git clone https://github.com/huggingface/optimum-habana.git --single-branch --branch v${OPTIMUM_HABANA_VER}
+
+# Note: Modify the requirements.txt file in the kubernetes directory for the specific example(s) that you want to run
+cd optimum-habana/examples/kubernetes
+
+# Set variables for your container registry and repository
+export REGISTRY=<Your container registry>
+export REPO=<Your container repository>
+
+# Build the images
+docker compose build
+
+# Push the optimum-habana-examples image to a container registry
+docker push <image name>:<tag>
+```
+
+## Helm Chart
+
+### Kubernetes resources
+
+This Kubernetes job uses a [Helm chart](https://helm.sh) with the following resources:
+* Job to run the Optimum Habana example script using HPU(s)
+* [Persistant volume claim](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#persistentvolumeclaims)
+  (PVC) backed by NFS to store output files
+* (Optional) Pod used to access the files from the PVC after the worker pod completes
+* (Optional) [Secret](https://kubernetes.io/docs/concepts/configuration/secret/) for a Hugging Face token, if gated
+  models are being used
+
+### Helm chart values
+
+The [Helm chart values file](https://helm.sh/docs/chart_template_guide/values_files/) is a yaml file with values that
+get passed to the chart when it's deployed to the cluster. These values specify the python script and parameters for
+your job, the name and tag of your Docker image, the number of HPU cards to use for the job, etc.
+
+<details>
+  <summary> Expand to see the values table </summary>
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| affinity | object | `{}` | Optionally provide node [affinities](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) to constrain which node your worker pod will be scheduled on. |
+| command[0] | string | `"python"` |  |
+| command[1] | string | `"/workspace/optimum-habana/examples/gaudi_spawn.py"` |  |
+| command[2] | string | `"--help"` |  |
+| env | list | `[{"name":"LOGLEVEL","value":"INFO"}]` | Define environment variables to set in the container |
+| envFrom | list | `[]` | Optionally define a config map's data as container environment variables |
+| hostIPC | bool | `false` | The default 64MB of shared memory for docker containers can be insufficient when using more than one HPU. Setting hostIPC: true allows reusing the host's shared memory space inside the container. |
+| image.pullPolicy | string | `"IfNotPresent"` | Determines when the kubelet will pull the image to the worker nodes. Choose from: `IfNotPresent`, `Always`, or `Never`. If updates to the image have been made, use `Always` to ensure the newest image is used. |
+| image.repository | string | `nil` | Repository and name of the docker image |
+| image.tag | string | `nil` | Tag of the docker image |
+| imagePullSecrets | list | `[]` | Optional [image pull secret](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/) to pull from a private registry |
+| nodeSelector | object | `{}` | Optionally specify a [node selector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) with labels the determine which node your worker pod will land on. |
+| podAnnotations | object | `{}` | Pod [annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/) to attach metadata to the job |
+| podSecurityContext | object | `{}` | Specify a pod security context to run as a non-root user |
+| resources.limits."habana.ai/gaudi" | int | `1` | Specify the number of Gaudi card(s) |
+| resources.limits.cpu | int | `16` | Specify [CPU resource](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#meaning-of-cpu) limits for the job |
+| resources.limits.hugepages-2Mi | string | `"4400Mi"` | Specify hugepages-2Mi limit for the job |
+| resources.limits.memory | string | `"128Gi"` | Specify [memory limits](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#meaning-of-memory) requests for the job |
+| resources.requests."habana.ai/gaudi" | int | `1` | Specify the number of Gaudi card(s) |
+| resources.requests.cpu | int | `16` | Specify [CPU resource](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#meaning-of-cpu) requests for the job |
+| resources.requests.hugepages-2Mi | string | `"4400Mi"` | Specify hugepages-2Mi requests for the job |
+| resources.requests.memory | string | `"128Gi"` | Specify [memory resource](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#meaning-of-memory) requests for the job |
+| secret.encodedToken | string | `nil` | Hugging Face token encoded using base64. |
+| secret.secretMountPath | string | `"/tmp/hf_token"` | If a token is provided, specify a mount path that will be used to set HF_TOKEN_PATH |
+| securityContext.privileged | bool | `true` | Run as privileged or unprivileged |
+| storage.accessModes | list | `["ReadWriteMany"]` | [Access modes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes) for the persistent volume. |
+| storage.deployDataAccessPod | bool | `true` | A data access pod will be deployed when set to true. This allows accessing the data from the PVC after the worker pod has completed. |
+| storage.pvcMountPath | string | `"/tmp/pvc-mount"` | Locaton where the PVC will be mounted in the pod |
+| storage.resources | object | `{"requests":{"storage":"30Gi"}}` | Storage [resources](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#resources) |
+| storage.storageClassName | string | `"nfs-client"` | Name of the storage class to use for the persistent volume claim. To list the available storage classes use: `kubectl get storageclass`. |
+| tolerations | list | `[]` | Optionally specify [tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) to allow the worker pod to land on a node with a taint. |
+
+</details>
+
+There is a [`values.yaml` files](values.yaml) that is intended to be used as a template to run an optimum-habana
+example script. Ensure that your container has the requirements needed to run the example, and then update the
+`values.yaml` file with your `image.repository` and `image.tag`. Then, update the `command` array with the script and
+parameters to run the example.
+
+Validated use cases can be found in the `ci` directory:
+
+| Values files path | HPUs | Description |
+|-------------------|------|-------------|
+| [`ci/single-card-glue-values.yaml`](ci/single-card-glue-values.yaml) | 1 | Uses a single card to [fine tune BERT large](../text-classification/README.md#single-card-training) (with whole word masking) on the text classification MRPC task using `run_glue.py`.
+| [`ci/multi-card-glue-values.yaml`](ci/multi-card-glue-values.yaml) | 2 | Uses 2 HPUs with the [`gaudi_spawn.py`](../gaudi_spawn.py) script to [fine tune BERT large](../text-classification/README.md#multi-card-training) (with whole word masking) on the text classification MRPC task using `run_glue.py`.
+| [`ci/single-card-lora-clm-values.yaml`](ci/single-card-lora-clm-values.yaml) | 1 | Uses a single card to [fine tune Llama1-7B](../language-modeling/README.md#peft) with LoRA using the `run_lora_clm.py` script.
+| [`ci/multi-card-lora-clm-values.yaml`](ci/multi-card-lora-clm-values.yaml) | 8 | Uses 8 HPUs with the [`gaudi_spawn.py`](../gaudi_spawn.py) script to [fine tune Llama1-7B](../language-modeling/README.md#peft) with LoRA using the `run_lora_clm.py` script.
+
+### Deploy job to the cluster
+
+After updating the values file for the example that you want to run, use the following command to deploy the job to
+your Kubernetes cluster.
+
+```bash
+cd examples/kubernetes
+
+helm install -f <path to values.yaml> optimum-habana-examples . -n <namespace>
+```
+
+After the job is deployed, you can check the status of the pods:
+```bash
+kubectl get pods -n <namespace>
+```
+
+To monitor a running job, you can view the logs of the worker pod:
+
+```bash
+kubectl logs <pod name> -n <namespace> -f
+```
+
+The data access pod can be used to copy artifacts from the persistent volume claim (for example, the trained model
+after fine tuning completes). Note that this requires that the data access pod be deployed to the cluster with the helm
+chart by setting `storage.deployDataAccessPod = true` in the values yaml file. The path to the files is defined in the
+`storage.pvcMountPath` value (this defaults to `/tmp/pvc-mount`). You can find the name of your data access pod using
+`kubectl get pods -n <namespace> | grep dataaccess`.
+
+```bash
+# Copy files from the PVC mount path to your local machine
+kubectl cp <data access pod name>:/tmp/pvc-mount . -n <namespace>
+```
+
+Finally, when your job is complete and you've copied all the artifacts that you need to your local machine, you can
+uninstall the helm job from the cluster:
+
+```bash
+helm uninstall optimum-habana-examples . -n <namespace>
+```
+
+----------------------------------------------
+Autogenerated from chart metadata using [helm-docs v1.13.1](https://github.com/norwoodj/helm-docs/releases/v1.13.1)

--- a/examples/kubernetes/README.md.gotmpl
+++ b/examples/kubernetes/README.md.gotmpl
@@ -35,14 +35,14 @@ Use the the following commands to build the containers:
 
 ```bash
 # Specify the base image name/tag
-export BASE_IMAGE_NAME=vault.habana.ai/gaudi-docker/1.15.1/ubuntu22.04/habanalabs/pytorch-installer-2.2.0
+export BASE_IMAGE_NAME=vault.habana.ai/gaudi-docker/1.16.1/ubuntu22.04/habanalabs/pytorch-installer-2.2.2
 export BASE_IMAGE_TAG=latest
 
 # Specify your Gaudi Software version and Optimum Habana version
-export GAUDI_SW_VER=1.15.1
-export OPTIMUM_HABANA_VER=1.11.1
+export GAUDI_SW_VER=1.16.1
+export OPTIMUM_HABANA_VER=1.12.0
 
-git clone https://github.com/huggingface/optimum-habana.git --single-branch --branch v${OPTIMUM_HABANA_VER}
+git clone https://github.com/huggingface/optimum-habana.git
 
 # Note: Modify the requirements.txt file in the kubernetes directory for the specific example(s) that you want to run
 cd optimum-habana/examples/kubernetes

--- a/examples/kubernetes/README.md.gotmpl
+++ b/examples/kubernetes/README.md.gotmpl
@@ -63,7 +63,7 @@ docker push <image name>:<tag>
 ### Kubernetes resources
 
 This Kubernetes job uses a [Helm chart](https://helm.sh) with the following resources:
-* Job to run the Optimum Habana example script using HPU(s)
+* Job to run the Optimum Habana example script using HPU(s) from a single node
 * [Persistant volume claim](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#persistentvolumeclaims)
   (PVC) backed by NFS to store output files
 * (Optional) Pod used to access the files from the PVC after the worker pod completes
@@ -93,9 +93,9 @@ Validated use cases can be found in the `ci` directory:
 | Values files path | HPUs | Description |
 |-------------------|------|-------------|
 | [`ci/single-card-glue-values.yaml`](ci/single-card-glue-values.yaml) | 1 | Uses a single card to [fine tune BERT large](../text-classification/README.md#single-card-training) (with whole word masking) on the text classification MRPC task using `run_glue.py`.
-| [`ci/multi-card-glue-values.yaml`](ci/multi-card-glue-values.yaml) | 2 | Uses 2 HPUs with the [`gaudi_spawn.py`](../gaudi_spawn.py) script to [fine tune BERT large](../text-classification/README.md#multi-card-training) (with whole word masking) on the text classification MRPC task using `run_glue.py`.
+| [`ci/multi-card-glue-values.yaml`](ci/multi-card-glue-values.yaml) | 2 | Uses 2 HPUs from a single node with the [`gaudi_spawn.py`](../gaudi_spawn.py) script to [fine tune BERT large](../text-classification/README.md#multi-card-training) (with whole word masking) on the text classification MRPC task using `run_glue.py`.
 | [`ci/single-card-lora-clm-values.yaml`](ci/single-card-lora-clm-values.yaml) | 1 | Uses a single card to [fine tune Llama1-7B](../language-modeling/README.md#peft) with LoRA using the `run_lora_clm.py` script.
-| [`ci/multi-card-lora-clm-values.yaml`](ci/multi-card-lora-clm-values.yaml) | 8 | Uses 8 HPUs with the [`gaudi_spawn.py`](../gaudi_spawn.py) script to [fine tune Llama1-7B](../language-modeling/README.md#peft) with LoRA using the `run_lora_clm.py` script.
+| [`ci/multi-card-lora-clm-values.yaml`](ci/multi-card-lora-clm-values.yaml) | 8 | Uses 8 HPUs from a single node with the [`gaudi_spawn.py`](../gaudi_spawn.py) script to [fine tune Llama1-7B](../language-modeling/README.md#peft) with LoRA using the `run_lora_clm.py` script.
 
 ### Deploy job to the cluster
 

--- a/examples/kubernetes/README.md.gotmpl
+++ b/examples/kubernetes/README.md.gotmpl
@@ -2,7 +2,7 @@
 
 {{ template "chart.badgesSection" . }}
 
-This folder contains a Dockerfile and [Helm chart](https://helm.sh) demonstrating how to run 🤗 Optimum Habana examples
+This folder contains a Dockerfile and [Helm chart](https://helm.sh) demonstrating how 🤗 Optimum Habana examples
 can be run using Intel® Gaudi® AI accelerator nodes from a vanilla Kubernetes cluster. The instructions below
 explain how to build the docker image and deploy the job to a Kubernetes cluster using Helm.
 
@@ -19,16 +19,17 @@ In order to build the docker images and deploy a job to Kubernetes you will need
 
 ### Cluster Requirements
 
-Your Kubernetes cluster will need the [Intel Gaudi Device Plugin for Kubernetes](https://docs.habana.ai/en/latest/Orchestration/Gaudi_Kubernetes/Device_Plugin_for_Kubernetes.html) in order to request and utilize the accelerators
-in the Kubernetes job. Also, ensure that your Kubernetes version is supported based on the
+Your Kubernetes cluster will need the [Intel Gaudi Device Plugin for Kubernetes](https://docs.habana.ai/en/latest/Orchestration/Gaudi_Kubernetes/Device_Plugin_for_Kubernetes.html)
+in order to request and utilize the accelerators in the Kubernetes job. Also, ensure that your Kubernetes version is supported based on the
 [support matrix](https://docs.habana.ai/en/latest/Support_Matrix/Support_Matrix.html#support-matrix).
 
 ## Container
 
-The [Dockerfile](Dockerfile) and [docker-compose.yaml](docker-compose.yaml) builds the following images:
+The [Dockerfile](Dockerfile) and [docker-compose.yaml](docker-compose.yaml) build the following images:
 
-* An `optimum-habana` base image that uses the [PyTorch Docker images for Gaudi](https://developer.habana.ai/catalog/pytorch-container/) as it's base, then installs optimum-habana and Deep Speed.
-* A `optimum-habana-examples` image is built on top of the `optimum-habana` base to includes installations from
+* An `optimum-habana` base image that uses the [PyTorch Docker images for Gaudi](https://developer.habana.ai/catalog/pytorch-container/) as it's base, and then installs
+optimum-habana and the Habana fork of Deep Speed.
+* An `optimum-habana-examples` image is built on top of the `optimum-habana` base to includes installations from
 `requirements.txt` files in the example directories and a clone of [this GitHub repository](https://github.com/huggingface/optimum-habana/) in order to run example scripts.
 
 Use the the following commands to build the containers:

--- a/examples/kubernetes/README.md.gotmpl
+++ b/examples/kubernetes/README.md.gotmpl
@@ -1,0 +1,140 @@
+# {{ template "chart.name" . }}
+
+{{ template "chart.badgesSection" . }}
+
+This folder contains a Dockerfile and [Helm chart](https://helm.sh) demonstrating how to run 🤗 Optimum Habana examples
+can be run using Intel® Gaudi® AI accelerator nodes from a vanilla Kubernetes cluster. The instructions below
+explain how to build the docker image and deploy the job to a Kubernetes cluster using Helm.
+
+## Requirements
+
+### Client System Requirements
+
+In order to build the docker images and deploy a job to Kubernetes you will need:
+
+* [Docker](https://docs.docker.com/engine/install/)
+* [Docker compose](https://docs.docker.com/compose/install/)
+* [kubectl](https://kubernetes.io/docs/tasks/tools/) installed and configured to access a cluster
+* [Helm CLI](https://helm.sh/docs/intro/install/)
+
+### Cluster Requirements
+
+Your Kubernetes cluster will need the [Intel Gaudi Device Plugin for Kubernetes](https://docs.habana.ai/en/latest/Orchestration/Gaudi_Kubernetes/Device_Plugin_for_Kubernetes.html) in order to request and utilize the accelerators
+in the Kubernetes job. Also, ensure that your Kubernetes version is supported based on the
+[support matrix](https://docs.habana.ai/en/latest/Support_Matrix/Support_Matrix.html#support-matrix).
+
+## Container
+
+The [Dockerfile](Dockerfile) and [docker-compose.yaml](docker-compose.yaml) builds the following images:
+
+* An `optimum-habana` base image that uses the [PyTorch Docker images for Gaudi](https://developer.habana.ai/catalog/pytorch-container/) as it's base, then installs optimum-habana and Deep Speed.
+* A `optimum-habana-examples` image is built on top of the `optimum-habana` base to includes installations from
+`requirements.txt` files in the example directories and a clone of [this GitHub repository](https://github.com/huggingface/optimum-habana/) in order to run example scripts.
+
+Use the the following commands to build the containers:
+
+```bash
+# Specify the base image name/tag
+export BASE_IMAGE_NAME=vault.habana.ai/gaudi-docker/1.15.1/ubuntu22.04/habanalabs/pytorch-installer-2.2.0
+export BASE_IMAGE_TAG=latest
+
+# Specify your Gaudi Software version and Optimum Habana version
+export GAUDI_SW_VER=1.15.1
+export OPTIMUM_HABANA_VER=1.11.1
+
+git clone https://github.com/huggingface/optimum-habana.git --single-branch --branch v${OPTIMUM_HABANA_VER}
+
+# Note: Modify the requirements.txt file in the kubernetes directory for the specific example(s) that you want to run
+cd optimum-habana/examples/kubernetes
+
+# Set variables for your container registry and repository
+export REGISTRY=<Your container registry>
+export REPO=<Your container repository>
+
+# Build the images
+docker compose build
+
+# Push the optimum-habana-examples image to a container registry
+docker push <image name>:<tag>
+```
+
+## Helm Chart
+
+### Kubernetes resources
+
+This Kubernetes job uses a [Helm chart](https://helm.sh) with the following resources:
+* Job to run the Optimum Habana example script using HPU(s)
+* [Persistant volume claim](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#persistentvolumeclaims)
+  (PVC) backed by NFS to store output files
+* (Optional) Pod used to access the files from the PVC after the worker pod completes
+* (Optional) [Secret](https://kubernetes.io/docs/concepts/configuration/secret/) for a Hugging Face token, if gated
+  models are being used
+
+### Helm chart values
+
+The [Helm chart values file](https://helm.sh/docs/chart_template_guide/values_files/) is a yaml file with values that
+get passed to the chart when it's deployed to the cluster. These values specify the python script and parameters for
+your job, the name and tag of your Docker image, the number of HPU cards to use for the job, etc.
+
+<details>
+  <summary> Expand to see the values table </summary>
+
+{{ template "chart.valuesTable" . }}
+
+</details>
+
+There is a [`values.yaml` files](values.yaml) that is intended to be used as a template to run an optimum-habana
+example script. Ensure that your container has the requirements needed to run the example, and then update the
+`values.yaml` file with your `image.repository` and `image.tag`. Then, update the `command` array with the script and
+parameters to run the example.
+
+Validated use cases can be found in the `ci` directory:
+
+| Values files path | HPUs | Description |
+|-------------------|------|-------------|
+| [`ci/single-card-glue-values.yaml`](ci/single-card-glue-values.yaml) | 1 | Uses a single card to [fine tune BERT large](../text-classification/README.md#single-card-training) (with whole word masking) on the text classification MRPC task using `run_glue.py`.
+| [`ci/multi-card-glue-values.yaml`](ci/multi-card-glue-values.yaml) | 2 | Uses 2 HPUs with the [`gaudi_spawn.py`](../gaudi_spawn.py) script to [fine tune BERT large](../text-classification/README.md#multi-card-training) (with whole word masking) on the text classification MRPC task using `run_glue.py`.
+| [`ci/single-card-lora-clm-values.yaml`](ci/single-card-lora-clm-values.yaml) | 1 | Uses a single card to [fine tune Llama1-7B](../language-modeling/README.md#peft) with LoRA using the `run_lora_clm.py` script.
+| [`ci/multi-card-lora-clm-values.yaml`](ci/multi-card-lora-clm-values.yaml) | 8 | Uses 8 HPUs with the [`gaudi_spawn.py`](../gaudi_spawn.py) script to [fine tune Llama1-7B](../language-modeling/README.md#peft) with LoRA using the `run_lora_clm.py` script.
+
+### Deploy job to the cluster
+
+After updating the values file for the example that you want to run, use the following command to deploy the job to
+your Kubernetes cluster.
+
+```bash
+cd examples/kubernetes
+
+helm install -f <path to values.yaml> optimum-habana-examples . -n <namespace>
+```
+
+After the job is deployed, you can check the status of the pods:
+```bash
+kubectl get pods -n <namespace>
+```
+
+To monitor a running job, you can view the logs of the worker pod:
+
+```bash
+kubectl logs <pod name> -n <namespace> -f
+```
+
+The data access pod can be used to copy artifacts from the persistent volume claim (for example, the trained model
+after fine tuning completes). Note that this requires that the data access pod be deployed to the cluster with the helm
+chart by setting `storage.deployDataAccessPod = true` in the values yaml file. The path to the files is defined in the
+`storage.pvcMountPath` value (this defaults to `/tmp/pvc-mount`). You can find the name of your data access pod using
+`kubectl get pods -n <namespace> | grep dataaccess`.
+
+```bash
+# Copy files from the PVC mount path to your local machine
+kubectl cp <data access pod name>:/tmp/pvc-mount . -n <namespace>
+```
+
+Finally, when your job is complete and you've copied all the artifacts that you need to your local machine, you can
+uninstall the helm job from the cluster:
+
+```bash
+helm uninstall optimum-habana-examples . -n <namespace>
+```
+
+{{ template "helm-docs.versionFooter" . }}

--- a/examples/kubernetes/ci/multi-card-glue-values.yaml
+++ b/examples/kubernetes/ci/multi-card-glue-values.yaml
@@ -22,8 +22,8 @@ podSecurityContext: {}
   # fsGroup: 2000
 
 securityContext:
-  # -- Run as privileged or unprivileged
-  privileged: true
+  # -- Run as privileged or unprivileged. Certain deployments may require running as privileged, check with your system admin.
+  privileged: false
 
 # -- The default 64MB of shared memory for docker containers can be insufficient when using more than one HPU. Setting hostIPC: true allows reusing the host's shared memory space inside the container.
 hostIPC: true

--- a/examples/kubernetes/ci/multi-card-glue-values.yaml
+++ b/examples/kubernetes/ci/multi-card-glue-values.yaml
@@ -1,0 +1,122 @@
+# Default values for examples.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+image:
+  # -- Determines when the kubelet will pull the image to the worker nodes. Choose from: `IfNotPresent`, `Always`, or `Never`. If updates to the image have been made, use `Always` to ensure the newest image is used.
+  pullPolicy: IfNotPresent
+  # -- Repository and name of the docker image
+  repository: 
+  # -- Tag of the docker image
+  tag: 
+
+imagePullSecrets: []
+
+# -- Pod [annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/) to attach metadata to the job
+podAnnotations: {}
+
+# -- Specify a pod security context to run as a non-root user
+podSecurityContext: {}
+  # runAsUser: 1000
+  # runAsGroup: 3000
+  # fsGroup: 2000
+
+securityContext:
+  # -- Run as privileged or unprivileged
+  privileged: true
+
+# -- The default 64MB of shared memory for docker containers can be insufficient when using more than one HPU. Setting hostIPC: true allows reusing the host's shared memory space inside the container.
+hostIPC: true
+
+# -- Define a config map's data as container environment variables
+envFrom: []
+
+# -- Define environment variables to set in the container
+env:
+- name: LOGLEVEL
+  value: INFO
+
+secret:
+  # -- Hugging Face token encoded using base64.
+  encodedToken:
+  # -- If a token is provided, specify a mount path that will be used to set HF_TOKEN_PATH
+  secretMountPath: /tmp/hf_token
+
+storage:
+  # -- Name of the storage class to use for the persistent volume claim. To list the available storage classes use: `kubectl get storageclass`.
+  storageClassName: nfs-client
+  # -- [Access modes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes) for the persistent volume.
+  accessModes:
+  - "ReadWriteMany"
+  # -- Storage [resources](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#resources)
+  resources:
+    requests:
+      storage: 30Gi
+  # -- Locaton where the PVC will be mounted in the pods
+  pvcMountPath: &pvcMountPath /tmp/pvc-mount
+  # -- A data access pod will be deployed when set to true
+  deployDataAccessPod: true
+
+resources:
+  limits:
+    # -- Specify the number of Gaudi card(s)
+    habana.ai/gaudi: &hpus "2"
+    # -- Specify [CPU resource](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#meaning-of-cpu) limits for the job
+    cpu: 16
+    # -- Specify [Memory limits](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#meaning-of-memory) requests for the job
+    memory: 128Gi
+    # -- Specify hugepages-2Mi requests for the job
+    hugepages-2Mi: 4400Mi
+  requests:
+    # -- Specify the number of Gaudi card(s)
+    habana.ai/gaudi: *hpus
+    # -- Specify [CPU resource](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#meaning-of-cpu) requests for the job
+    cpu: 16
+    # -- Specify [Memory resource](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#meaning-of-memory) requests for the job
+    memory: 128Gi
+    # -- Specify hugepages-2Mi requests for the job
+    hugepages-2Mi: 4400Mi
+
+# Define the command to run in the container
+command:
+  - python
+  - /workspace/optimum-habana/examples/gaudi_spawn.py
+  - --world_size
+  - *hpus
+  - --use_mpi
+  - /workspace/optimum-habana/examples/text-classification/run_glue.py
+  - --model_name_or_path
+  - bert-large-uncased-whole-word-masking
+  - --gaudi_config_name
+  - Habana/bert-large-uncased-whole-word-masking
+  - --task_name
+  - mrpc
+  - --do_train
+  - --do_eval
+  - --per_device_train_batch_size
+  - "32"
+  - --per_device_eval_batch_size
+  - "8"
+  - --learning_rate
+  - "3e-5"
+  - --num_train_epochs
+  - "3"
+  - --max_seq_length
+  - "128"
+  - --output_dir
+  - *pvcMountPath
+  - --use_habana
+  - --use_lazy_mode
+  - --use_hpu_graphs_for_inference
+  - --throughput_warmup_steps
+  - "3"
+  - --bf16
+
+# -- Optionally specify a [node selector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) with labels the determine which node your worker pod will land on
+nodeSelector: {}
+
+# -- Optionally specify [tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) to allow the worker pod to land on a node with a taint.
+tolerations: []
+
+# -- Optionally provide node [affinities](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) to constrain which node your worker pod will be scheduled on
+affinity: {}

--- a/examples/kubernetes/ci/multi-card-lora-clm-values.yaml
+++ b/examples/kubernetes/ci/multi-card-lora-clm-values.yaml
@@ -22,8 +22,8 @@ podSecurityContext: {}
   # fsGroup: 2000
 
 securityContext:
-  # -- Run as privileged or unprivileged
-  privileged: true
+  # -- Run as privileged or unprivileged. Certain deployments may require running as privileged, check with your system admin.
+  privileged: false
 
 # -- The default 64MB of shared memory for docker containers can be insufficient when using more than one HPU. Setting hostIPC: true allows reusing the host's shared memory space inside the container.
 hostIPC: true

--- a/examples/kubernetes/ci/multi-card-lora-clm-values.yaml
+++ b/examples/kubernetes/ci/multi-card-lora-clm-values.yaml
@@ -1,0 +1,140 @@
+# Default values for examples.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+image:
+  # -- Determines when the kubelet will pull the image to the worker nodes. Choose from: `IfNotPresent`, `Always`, or `Never`. If updates to the image have been made, use `Always` to ensure the newest image is used.
+  pullPolicy: IfNotPresent
+  # -- Repository and name of the docker image
+  repository: 
+  # -- Tag of the docker image
+  tag: 
+
+imagePullSecrets: []
+
+# -- Pod [annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/) to attach metadata to the job
+podAnnotations: {}
+
+# -- Specify a pod security context to run as a non-root user
+podSecurityContext: {}
+  # runAsUser: 1000
+  # runAsGroup: 3000
+  # fsGroup: 2000
+
+securityContext:
+  # -- Run as privileged or unprivileged
+  privileged: true
+
+# -- The default 64MB of shared memory for docker containers can be insufficient when using more than one HPU. Setting hostIPC: true allows reusing the host's shared memory space inside the container.
+hostIPC: true
+
+# -- Define a config map's data as container environment variables
+envFrom: 
+
+# -- Define environment variables to set in the container
+env:
+- name: LOGLEVEL
+  value: INFO
+
+secret:
+  # -- Hugging Face token encoded using base64.
+  encodedToken:
+  # -- If a token is provided, specify a mount path that will be used to set HF_TOKEN_PATH
+  secretMountPath: /tmp/hf_token
+
+storage:
+  # -- Name of the storage class to use for the persistent volume claim. To list the available storage classes use: `kubectl get storageclass`.
+  storageClassName: nfs-client
+  # -- [Access modes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes) for the persistent volume.
+  accessModes:
+  - "ReadWriteMany"
+  # -- Storage [resources](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#resources)
+  resources:
+    requests:
+      storage: 30Gi
+  # -- Locaton where the PVC will be mounted in the pods
+  pvcMountPath: &pvcMountPath /tmp/pvc-mount
+  # -- A data access pod will be deployed when set to true
+  deployDataAccessPod: true
+
+resources:
+  limits:
+    # -- Specify the number of Gaudi card(s)
+    habana.ai/gaudi: &hpus "8"
+    # -- Specify [CPU resource](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#meaning-of-cpu) limits for the job
+    cpu: 128
+    # -- Specify [Memory limits](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#meaning-of-memory) requests for the job
+    memory: 512Gi
+    # -- Specify hugepages-2Mi requests for the job
+    hugepages-2Mi: 35202Mi
+  requests:
+    # -- Specify the number of Gaudi card(s)
+    habana.ai/gaudi: *hpus
+    # -- Specify [CPU resource](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#meaning-of-cpu) requests for the job
+    cpu: 128
+    # -- Specify [Memory resource](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#meaning-of-memory) requests for the job
+    memory: 512Gi
+    # -- Specify hugepages-2Mi requests for the job
+    hugepages-2Mi: 35202Mi
+
+
+# Define the command to run in the container
+command:
+  - python
+  - /workspace/optimum-habana/examples/gaudi_spawn.py
+  - --world_size
+  - *hpus
+  - --use_mpi
+  - /workspace/optimum-habana/examples/language-modeling/run_lora_clm.py 
+  - --model_name_or_path
+  - huggyllama/llama-7b 
+  - --dataset_name
+  - tatsu-lab/alpaca 
+  - --bf16=True
+  - --output_dir
+  - *pvcMountPath
+  - --num_train_epochs
+  - "3"
+  - --per_device_train_batch_size
+  - "12"
+  - --evaluation_strategy
+  - "no" 
+  - --save_strategy
+  - "no" 
+  - --learning_rate
+  - "1e-4" 
+  - --warmup_ratio
+  - "0.03" 
+  - --lr_scheduler_type
+  - "constant" 
+  - --max_grad_norm
+  - "0.3" 
+  - --logging_steps
+  - "1"
+  - --do_train 
+  - --do_eval 
+  - --use_habana 
+  - --use_lazy_mode 
+  - --throughput_warmup_steps
+  - "3"
+  - --lora_rank
+  - "8" 
+  - --lora_alph=16 
+  - --lora_dropout=0.05 
+  - --lora_target_modules
+  - "q_proj"
+  - "v_proj" 
+  - --dataset_concatenation 
+  - --max_seq_length=512 
+  - --low_cpu_mem_usage=True 
+  - --validation_split_percentage=4 
+  - --adam_epsilon=1e-08
+
+# -- Optionally specify a [node selector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) with labels the determine which node your worker pod will land on
+nodeSelector: {}
+
+# -- Optionally specify [tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) to allow the worker pod to land on a node with a taint.
+tolerations: []
+
+# -- Optionally provide node [affinities](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) to constrain which node your worker pod will be scheduled on
+affinity: {}

--- a/examples/kubernetes/ci/single-card-glue-values.yaml
+++ b/examples/kubernetes/ci/single-card-glue-values.yaml
@@ -1,0 +1,116 @@
+# Default values for examples.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+image:
+  # -- Determines when the kubelet will pull the image to the worker nodes. Choose from: `IfNotPresent`, `Always`, or `Never`. If updates to the image have been made, use `Always` to ensure the newest image is used.
+  pullPolicy: IfNotPresent
+  # -- Repository and name of the docker image
+  repository: 
+  # -- Tag of the docker image
+  tag: 
+
+imagePullSecrets: []
+
+# -- Pod [annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/) to attach metadata to the job
+podAnnotations: {}
+
+# -- Specify a pod security context to run as a non-root user
+podSecurityContext: {}
+  # runAsUser: 1000
+  # runAsGroup: 3000
+  # fsGroup: 2000
+
+securityContext:
+  # -- Run as privileged or unprivileged
+  privileged: true
+
+# -- The default 64MB of shared memory for docker containers can be insufficient when using more than one HPU. Setting hostIPC: true allows reusing the host's shared memory space inside the container.
+hostIPC: false
+
+# -- Define a config map's data as container environment variables
+envFrom: []
+
+# -- Define environment variables to set in the container
+env:
+- name: LOGLEVEL
+  value: INFO
+
+secret:
+  # -- Hugging Face token encoded using base64.
+  encodedToken:
+  # -- If a token is provided, specify a mount path that will be used to set HF_TOKEN_PATH
+  secretMountPath: /tmp/hf_token
+
+storage:
+  # -- Name of the storage class to use for the persistent volume claim. To list the available storage classes use: `kubectl get storageclass`.
+  storageClassName: nfs-client
+  # -- [Access modes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes) for the persistent volume.
+  accessModes:
+  - "ReadWriteMany"
+  # -- Storage [resources](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#resources)
+  resources:
+    requests:
+      storage: 30Gi
+  # -- Locaton where the PVC will be mounted in the pods
+  pvcMountPath: &pvcMountPath /tmp/pvc-mount
+  # -- A data access pod will be deployed when set to true
+  deployDataAccessPod: true
+
+resources:
+  limits:
+    # -- Specify the number of Gaudi card(s)
+    habana.ai/gaudi: &hpus 1
+    # -- Specify [CPU resource](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#meaning-of-cpu) limits for the job
+    cpu: 16
+    # -- Specify [Memory limits](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#meaning-of-memory) requests for the job
+    memory: 128Gi
+    # -- Specify hugepages-2Mi requests for the job
+    hugepages-2Mi: 4400Mi
+  requests:
+    # -- Specify the number of Gaudi card(s)
+    habana.ai/gaudi: *hpus
+    # -- Specify [CPU resource](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#meaning-of-cpu) requests for the job
+    cpu: 16
+    # -- Specify [Memory resource](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#meaning-of-memory) requests for the job
+    memory: 128Gi
+    # -- Specify hugepages-2Mi requests for the job
+    hugepages-2Mi: 4400Mi
+
+# Define the command to run in the container
+command:
+  - python
+  - /workspace/optimum-habana/examples/text-classification/run_glue.py
+  - --model_name_or_path
+  - bert-large-uncased-whole-word-masking
+  - --gaudi_config_name
+  - Habana/bert-large-uncased-whole-word-masking
+  - --task_name
+  - mrpc
+  - --do_train
+  - --do_eval
+  - --per_device_train_batch_size
+  - "32"
+  - --learning_rate
+  - "3e-5"
+  - --num_train_epochs
+  - "3"
+  - --max_seq_length
+  - "128"
+  - --output_dir
+  - *pvcMountPath
+  - --use_habana
+  - --use_lazy_mode
+  - --use_hpu_graphs_for_inference
+  - --throughput_warmup_steps
+  - "3"
+  - --bf16
+
+# -- Optionally specify a [node selector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) with labels the determine which node your worker pod will land on
+nodeSelector: {}
+
+# -- Optionally specify [tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) to allow the worker pod to land on a node with a taint.
+tolerations: []
+
+# -- Optionally provide node [affinities](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) to constrain which node your worker pod will be scheduled on
+affinity: {}

--- a/examples/kubernetes/ci/single-card-glue-values.yaml
+++ b/examples/kubernetes/ci/single-card-glue-values.yaml
@@ -22,8 +22,8 @@ podSecurityContext: {}
   # fsGroup: 2000
 
 securityContext:
-  # -- Run as privileged or unprivileged
-  privileged: true
+  # -- Run as privileged or unprivileged. Certain deployments may require running as privileged, check with your system admin.
+  privileged: false
 
 # -- The default 64MB of shared memory for docker containers can be insufficient when using more than one HPU. Setting hostIPC: true allows reusing the host's shared memory space inside the container.
 hostIPC: false

--- a/examples/kubernetes/ci/single-card-lora-clm-values.yaml
+++ b/examples/kubernetes/ci/single-card-lora-clm-values.yaml
@@ -22,8 +22,8 @@ podSecurityContext: {}
   # fsGroup: 2000
 
 securityContext:
-  # -- Run as privileged or unprivileged
-  privileged: true
+  # -- Run as privileged or unprivileged. Certain deployments may require running as privileged, check with your system admin.
+  privileged: false
 
 # -- The default 64MB of shared memory for docker containers can be insufficient when using more than one HPU. Setting hostIPC: true allows reusing the host's shared memory space inside the container.
 hostIPC: false

--- a/examples/kubernetes/ci/single-card-lora-clm-values.yaml
+++ b/examples/kubernetes/ci/single-card-lora-clm-values.yaml
@@ -1,0 +1,135 @@
+# Default values for examples.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+image:
+  # -- Determines when the kubelet will pull the image to the worker nodes. Choose from: `IfNotPresent`, `Always`, or `Never`. If updates to the image have been made, use `Always` to ensure the newest image is used.
+  pullPolicy: IfNotPresent
+  # -- Repository and name of the docker image
+  repository: 
+  # -- Tag of the docker image
+  tag: 
+
+imagePullSecrets: []
+
+# -- Pod [annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/) to attach metadata to the job
+podAnnotations: {}
+
+# -- Specify a pod security context to run as a non-root user
+podSecurityContext: {}
+  # runAsUser: 1000
+  # runAsGroup: 3000
+  # fsGroup: 2000
+
+securityContext:
+  # -- Run as privileged or unprivileged
+  privileged: true
+
+# -- The default 64MB of shared memory for docker containers can be insufficient when using more than one HPU. Setting hostIPC: true allows reusing the host's shared memory space inside the container.
+hostIPC: false
+
+# -- Define a config map's data as container environment variables
+envFrom: []
+
+# -- Define environment variables to set in the container
+env:
+- name: LOGLEVEL
+  value: INFO
+
+secret:
+  # -- Hugging Face token encoded using base64.
+  encodedToken:
+  # -- If a token is provided, specify a mount path that will be used to set HF_TOKEN_PATH
+  secretMountPath: /tmp/hf_token
+
+storage:
+  # -- Name of the storage class to use for the persistent volume claim. To list the available storage classes use: `kubectl get storageclass`.
+  storageClassName: nfs-client
+  # -- [Access modes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes) for the persistent volume.
+  accessModes:
+  - "ReadWriteMany"
+  # -- Storage [resources](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#resources)
+  resources:
+    requests:
+      storage: 30Gi
+  # -- Locaton where the PVC will be mounted in the pods
+  pvcMountPath: &pvcMountPath /tmp/pvc-mount
+  # -- A data access pod will be deployed when set to true
+  deployDataAccessPod: true
+
+resources:
+  limits:
+    # -- Specify the number of Gaudi card(s)
+    habana.ai/gaudi: &hpus 1
+    # -- Specify [CPU resource](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#meaning-of-cpu) limits for the job
+    cpu: 16
+    # -- Specify [Memory limits](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#meaning-of-memory) requests for the job
+    memory: 128Gi
+    # -- Specify hugepages-2Mi requests for the job
+    hugepages-2Mi: 4400Mi
+  requests:
+    # -- Specify the number of Gaudi card(s)
+    habana.ai/gaudi: *hpus
+    # -- Specify [CPU resource](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#meaning-of-cpu) requests for the job
+    cpu: 16
+    # -- Specify [Memory resource](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#meaning-of-memory) requests for the job
+    memory: 128Gi
+    # -- Specify hugepages-2Mi requests for the job
+    hugepages-2Mi: 4400Mi
+
+# Define the command to run in the container
+command:
+  - python
+  - /workspace/optimum-habana/examples/language-modeling/run_lora_clm.py 
+  - --model_name_or_path
+  - huggyllama/llama-7b 
+  - --dataset_name
+  - tatsu-lab/alpaca 
+  - --bf16=True
+  - --output_dir
+  - *pvcMountPath
+  - --num_train_epochs
+  - "3"
+  - --per_device_train_batch_size
+  - "16"
+  - --evaluation_strategy
+  - "no" 
+  - --save_strategy
+  - "no" 
+  - --learning_rate
+  - "1e-4" 
+  - --warmup_ratio
+  - "0.03" 
+  - --lr_scheduler_type
+  - "constant" 
+  - --max_grad_norm
+  - "0.3" 
+  - --logging_steps
+  - "1"
+  - --do_train 
+  - --do_eval 
+  - --use_habana 
+  - --use_lazy_mode 
+  - --throughput_warmup_steps
+  - "3"
+  - --lora_rank
+  - "8" 
+  - --lora_alph=16 
+  - --lora_dropout=0.05 
+  - --lora_target_modules
+  - "q_proj"
+  - "v_proj" 
+  - --dataset_concatenation 
+  - --max_seq_length=512 
+  - --low_cpu_mem_usage=True 
+  - --validation_split_percentage=4 
+  - --adam_epsilon=1e-08
+
+# -- Optionally specify a [node selector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) with labels the determine which node your worker pod will land on
+nodeSelector: {}
+
+# -- Optionally specify [tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) to allow the worker pod to land on a node with a taint.
+tolerations: []
+
+# -- Optionally provide node [affinities](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) to constrain which node your worker pod will be scheduled on
+affinity: {}

--- a/examples/kubernetes/docker-compose.yaml
+++ b/examples/kubernetes/docker-compose.yaml
@@ -5,29 +5,30 @@ services:
         http_proxy: ${http_proxy}
         https_proxy: ${https_proxy}
         no_proxy: ""
-        BASE_IMAGE_NAME: ${BASE_IMAGE_NAME:-vault.habana.ai/gaudi-docker/1.15.1/ubuntu22.04/habanalabs/pytorch-installer-2.2.0}
+        BASE_IMAGE_NAME: ${BASE_IMAGE_NAME:-vault.habana.ai/gaudi-docker/1.16.1/ubuntu22.04/habanalabs/pytorch-installer-2.2.2}
         BASE_IMAGE_TAG: ${BASE_IMAGE_TAG:-latest}
-        GAUDI_SW_VER: 1.15.1
-        OPTIMUM_HABANA_VER: 1.11.1
+        GAUDI_SW_VER: 1.16.1
+        OPTIMUM_HABANA_VER: 1.12.0
         REGISTRY: ${REGISTRY}
         REPO: ${REPO}
       context: .
       labels:
-        org.opencontainers.base.name: "${BASE_IMAGE_NAME:-vault.habana.ai/gaudi-docker/1.15.1/ubuntu22.04/habanalabs/pytorch-installer-2.2.0}:${BASE_IMAGE_TAG:-latest}" 
+        org.opencontainers.base.name: "${BASE_IMAGE_NAME:-vault.habana.ai/gaudi-docker/1.16.1/ubuntu22.04/habanalabs/pytorch-installer-2.2.2}:${BASE_IMAGE_TAG:-latest}" 
         org.opencontainers.image.title: "Optimum for Intel® Gaudi® Accelerators"
-        org.opencontainers.image.version: gaudi-${GAUDI_SW_VER:-1.15.1}-optimum-habana-${OPTIMUM_HABANA_VER:-1.11.1}
+        org.opencontainers.image.version: gaudi-${GAUDI_SW_VER:-1.16.1}-optimum-habana-${OPTIMUM_HABANA_VER:-1.12.0}
     command: >
       sh -c "python -c 'from optimum import habana; print(\"optimum-habana:\", habana.__version__)'"
-    image: ${REGISTRY}/${REPO}:b-${GITHUB_RUN_NUMBER:-0}-gaudi-${GAUDI_SW_VER:-1.15.1}-optimum-habana-${OPTIMUM_HABANA_VER:-1.11.1}
+    image: ${REGISTRY}/${REPO}:b-${GITHUB_RUN_NUMBER:-0}-gaudi-${GAUDI_SW_VER:-1.16.1}-optimum-habana-${OPTIMUM_HABANA_VER:-1.12.0}
     pull_policy: always
   optimum-habana-examples:
     build:
       labels:
-        org.opencontainers.base.name: "${REGISTRY}/${REPO}:gaudi-${GAUDI_SW_VER:-1.15.1}-optimum-habana-${OPTIMUM_HABANA_VER:-1.11.1}"
+        org.opencontainers.base.name: "${REGISTRY}/${REPO}:gaudi-${GAUDI_SW_VER:-1.16.1}-optimum-habana-${OPTIMUM_HABANA_VER:-1.12.0}"
         org.opencontainers.image.title: "Optimum for Intel® Gaudi® Accelerators Examples"
-        org.opencontainers.image.version: gaudi-${GAUDI_SW_VER:-1.15.1}-optimum-habana-examples-${OPTIMUM_HABANA_VER:-1.11.1}
+        org.opencontainers.image.version: gaudi-${GAUDI_SW_VER:-1.16.1}-optimum-habana-examples-${OPTIMUM_HABANA_VER:-1.12.0}
       target: optimum-habana-examples
     command: >
       sh -c "python -c 'from optimum import habana; print(\"optimum-habana:\", habana.__version__)'"
     extends: optimum-habana
-    image: ${REGISTRY}/${REPO}:b-${GITHUB_RUN_NUMBER:-0}-gaudi-${GAUDI_SW_VER:-1.15.1}-optimum-habana-examples-${OPTIMUM_HABANA_VER:-1.11.1}
+    image: ${REGISTRY}/${REPO}:b-${GITHUB_RUN_NUMBER:-0}-gaudi-${GAUDI_SW_VER:-1.16.1}-optimum-habana-examples-${OPTIMUM_HABANA_VER:-1.12.0}
+

--- a/examples/kubernetes/docker-compose.yaml
+++ b/examples/kubernetes/docker-compose.yaml
@@ -13,8 +13,7 @@ services:
         REPO: ${REPO}
       context: .
       labels:
-        org.opencontainers.base.name: "vault.habana.ai/gaudi-docker/1.15.1/ubuntu22.04/habanalabs/pytorch-installer-2.2.0:latest"
-        org.opencontainers.image.name: "intel/ai-workflows"
+        org.opencontainers.base.name: "${BASE_IMAGE_NAME:-vault.habana.ai/gaudi-docker/1.15.1/ubuntu22.04/habanalabs/pytorch-installer-2.2.0}:${BASE_IMAGE_TAG:-latest}" 
         org.opencontainers.image.title: "Optimum for Intel® Gaudi® Accelerators"
         org.opencontainers.image.version: gaudi-${GAUDI_SW_VER:-1.15.1}-optimum-habana-${OPTIMUM_HABANA_VER:-1.11.1}
     command: >
@@ -24,7 +23,7 @@ services:
   optimum-habana-examples:
     build:
       labels:
-        org.opencontainers.base.name: "intel/ai-workflows:gaudi-${GAUDI_SW_VER:-1.15.1}-optimum-habana-${OPTIMUM_HABANA_VER:-1.11.1}"
+        org.opencontainers.base.name: "${REGISTRY}/${REPO}:gaudi-${GAUDI_SW_VER:-1.15.1}-optimum-habana-${OPTIMUM_HABANA_VER:-1.11.1}"
         org.opencontainers.image.title: "Optimum for Intel® Gaudi® Accelerators Examples"
         org.opencontainers.image.version: gaudi-${GAUDI_SW_VER:-1.15.1}-optimum-habana-examples-${OPTIMUM_HABANA_VER:-1.11.1}
       target: optimum-habana-examples

--- a/examples/kubernetes/docker-compose.yaml
+++ b/examples/kubernetes/docker-compose.yaml
@@ -1,0 +1,34 @@
+services:
+  optimum-habana:
+    build:
+      args:
+        http_proxy: ${http_proxy}
+        https_proxy: ${https_proxy}
+        no_proxy: ""
+        BASE_IMAGE_NAME: ${BASE_IMAGE_NAME:-vault.habana.ai/gaudi-docker/1.15.1/ubuntu22.04/habanalabs/pytorch-installer-2.2.0}
+        BASE_IMAGE_TAG: ${BASE_IMAGE_TAG:-latest}
+        GAUDI_SW_VER: 1.15.1
+        OPTIMUM_HABANA_VER: 1.11.1
+        REGISTRY: ${REGISTRY}
+        REPO: ${REPO}
+      context: .
+      labels:
+        org.opencontainers.base.name: "vault.habana.ai/gaudi-docker/1.15.1/ubuntu22.04/habanalabs/pytorch-installer-2.2.0:latest"
+        org.opencontainers.image.name: "intel/ai-workflows"
+        org.opencontainers.image.title: "Optimum for Intel® Gaudi® Accelerators"
+        org.opencontainers.image.version: gaudi-${GAUDI_SW_VER:-1.15.1}-optimum-habana-${OPTIMUM_HABANA_VER:-1.11.1}
+    command: >
+      sh -c "python -c 'from optimum import habana; print(\"optimum-habana:\", habana.__version__)'"
+    image: ${REGISTRY}/${REPO}:b-${GITHUB_RUN_NUMBER:-0}-gaudi-${GAUDI_SW_VER:-1.15.1}-optimum-habana-${OPTIMUM_HABANA_VER:-1.11.1}
+    pull_policy: always
+  optimum-habana-examples:
+    build:
+      labels:
+        org.opencontainers.base.name: "intel/ai-workflows:gaudi-${GAUDI_SW_VER:-1.15.1}-optimum-habana-${OPTIMUM_HABANA_VER:-1.11.1}"
+        org.opencontainers.image.title: "Optimum for Intel® Gaudi® Accelerators Examples"
+        org.opencontainers.image.version: gaudi-${GAUDI_SW_VER:-1.15.1}-optimum-habana-examples-${OPTIMUM_HABANA_VER:-1.11.1}
+      target: optimum-habana-examples
+    command: >
+      sh -c "python -c 'from optimum import habana; print(\"optimum-habana:\", habana.__version__)'"
+    extends: optimum-habana
+    image: ${REGISTRY}/${REPO}:b-${GITHUB_RUN_NUMBER:-0}-gaudi-${GAUDI_SW_VER:-1.15.1}-optimum-habana-examples-${OPTIMUM_HABANA_VER:-1.11.1}

--- a/examples/kubernetes/requirements.txt
+++ b/examples/kubernetes/requirements.txt
@@ -1,0 +1,2 @@
+-r optimum-habana/examples/language-modeling/requirements.txt
+-r optimum-habana/examples/text-classification/requirements.txt

--- a/examples/kubernetes/templates/dataaccess.yaml
+++ b/examples/kubernetes/templates/dataaccess.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.storage.deployDataAccessPod}}
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ .Release.Name }}-dataaccess
+spec:
+  containers:
+  - name: busybox
+    image: busybox:latest
+    command: ['sleep', 'infinity']
+    volumeMounts:
+    - name: pvc-volume
+      mountPath: {{ .Values.storage.pvcMountPath }}
+  volumes:
+  - name: pvc-volume
+    persistentVolumeClaim:
+      claimName: {{ .Release.Name }}-pvc
+{{- end }}

--- a/examples/kubernetes/templates/gaudi-job.yaml
+++ b/examples/kubernetes/templates/gaudi-job.yaml
@@ -1,0 +1,68 @@
+apiVersion: "batch/v1"
+kind: Job
+metadata:
+  name: {{ .Release.Name }}-gaudijob
+spec:
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      hostIPC: {{ .Values.hostIPC }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Release.Name }}-gaudijob-container
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            {{- toYaml .Values.command | nindent 12 }}
+          {{- with .Values.envFrom }}
+          envFrom:
+            {{- toYaml . | nindent 10 }}
+          {{- end }}
+          env:
+          {{- if .Values.secret.encodedToken}}
+          - name: HF_TOKEN_PATH
+            value: {{ .Values.secret.secretMountPath }}/token
+          {{- end }}
+            {{- toYaml .Values.env | nindent 10 }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+          - name: pvc-volume
+            mountPath: {{ .Values.storage.pvcMountPath }}
+          {{- if .Values.secret.encodedToken}}
+          - name: secret-volume
+            mountPath: {{ .Values.secret.secretMountPath }}
+          {{- end }}
+      restartPolicy: Never
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+      - name: pvc-volume
+        persistentVolumeClaim:
+          claimName: {{ .Release.Name }}-pvc
+      {{- if .Values.secret.encodedToken}}
+      - name: secret-volume
+        secret:
+          secretName: {{ .Release.Name }}-secret
+      {{- end }}

--- a/examples/kubernetes/templates/gaudi-job.yaml
+++ b/examples/kubernetes/templates/gaudi-job.yaml
@@ -66,3 +66,4 @@ spec:
         secret:
           secretName: {{ .Release.Name }}-secret
       {{- end }}
+

--- a/examples/kubernetes/templates/pvc.yaml
+++ b/examples/kubernetes/templates/pvc.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ .Release.Name }}-pvc
+spec:
+  storageClassName: {{ .Values.storage.storageClassName }}
+  {{- with .Values.storage.accessModes }}
+  accessModes:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.storage.resources }}
+  resources:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}

--- a/examples/kubernetes/templates/secret.yaml
+++ b/examples/kubernetes/templates/secret.yaml
@@ -1,0 +1,9 @@
+{{- if .Values.secret.encodedToken}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Release.Name }}-secret
+type: Opaque
+data:
+  token: {{ .Values.secret.encodedToken }}
+{{- end }}

--- a/examples/kubernetes/values.yaml
+++ b/examples/kubernetes/values.yaml
@@ -1,0 +1,94 @@
+# Default values for examples.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+image:
+  # -- Determines when the kubelet will pull the image to the worker nodes. Choose from: `IfNotPresent`, `Always`, or `Never`. If updates to the image have been made, use `Always` to ensure the newest image is used.
+  pullPolicy: IfNotPresent
+  # -- Repository and name of the docker image
+  repository: 
+  # -- Tag of the docker image
+  tag: 
+
+# -- Optional [image pull secret](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/) to pull from a private registry
+imagePullSecrets: []
+
+# -- Pod [annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/) to attach metadata to the job
+podAnnotations: {}
+
+# -- Specify a pod security context to run as a non-root user
+podSecurityContext: {}
+  # runAsUser: 1000
+  # runAsGroup: 3000
+  # fsGroup: 2000
+
+securityContext:
+  # -- Run as privileged or unprivileged
+  privileged: true
+
+# -- The default 64MB of shared memory for docker containers can be insufficient when using more than one HPU. Setting hostIPC: true allows reusing the host's shared memory space inside the container.
+hostIPC: false
+
+# -- Optionally define a config map's data as container environment variables
+envFrom: []
+
+# -- Define environment variables to set in the container
+env:
+- name: LOGLEVEL
+  value: INFO
+
+secret:
+  # -- Hugging Face token encoded using base64.
+  encodedToken:
+  # -- If a token is provided, specify a mount path that will be used to set HF_TOKEN_PATH
+  secretMountPath: /tmp/hf_token
+
+storage:
+  # -- Name of the storage class to use for the persistent volume claim. To list the available storage classes use: `kubectl get storageclass`.
+  storageClassName: nfs-client
+  # -- [Access modes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes) for the persistent volume.
+  accessModes:
+  - "ReadWriteMany"
+  # -- Storage [resources](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#resources)
+  resources:
+    requests:
+      storage: 30Gi
+  # -- Locaton where the PVC will be mounted in the pod
+  pvcMountPath: &pvcMountPath /tmp/pvc-mount
+  # -- A data access pod will be deployed when set to true. This allows accessing the data from the PVC after the worker pod has completed.
+  deployDataAccessPod: true
+
+resources:
+  limits:
+    # -- Specify the number of Gaudi card(s)
+    habana.ai/gaudi: &hpus 1
+    # -- Specify [CPU resource](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#meaning-of-cpu) limits for the job
+    cpu: 16
+    # -- Specify [memory limits](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#meaning-of-memory) requests for the job
+    memory: 128Gi
+    # -- Specify hugepages-2Mi limit for the job
+    hugepages-2Mi: 4400Mi
+  requests:
+    # -- Specify the number of Gaudi card(s)
+    habana.ai/gaudi: *hpus
+    # -- Specify [CPU resource](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#meaning-of-cpu) requests for the job
+    cpu: 16
+    # -- Specify [memory resource](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#meaning-of-memory) requests for the job
+    memory: 128Gi
+    # -- Specify hugepages-2Mi requests for the job
+    hugepages-2Mi: 4400Mi
+
+# Define the command to run in the container
+command:
+  - python
+  - /workspace/optimum-habana/examples/gaudi_spawn.py
+  - --help
+
+# -- Optionally specify a [node selector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) with labels the determine which node your worker pod will land on.
+nodeSelector: {}
+
+# -- Optionally specify [tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) to allow the worker pod to land on a node with a taint.
+tolerations: []
+
+# -- Optionally provide node [affinities](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) to constrain which node your worker pod will be scheduled on.
+affinity: {}

--- a/examples/kubernetes/values.yaml
+++ b/examples/kubernetes/values.yaml
@@ -23,8 +23,8 @@ podSecurityContext: {}
   # fsGroup: 2000
 
 securityContext:
-  # -- Run as privileged or unprivileged
-  privileged: true
+  # -- Run as privileged or unprivileged. Certain deployments may require running as privileged, check with your system admin.
+  privileged: false
 
 # -- The default 64MB of shared memory for docker containers can be insufficient when using more than one HPU. Setting hostIPC: true allows reusing the host's shared memory space inside the container.
 hostIPC: false


### PR DESCRIPTION
# What does this PR do?

This PR adds a helm chart, Dockerfile/docker compose, and instructions for running the optimum-habana examples using Kubernetes.

I added an `examples/kubernetes` directory, which is similar to `examples/multi-node-training` in that it's a general example that can be used with any of the other examples.

Since the docker images isn't published to a repository anywhere at this time, the user will need to build and push the container before deploying the helm chart. The Dockerfile uses the Habana Gaudi docker image and it's base and then installs optimum-habana, Habana's fork of DeepSpeed, and a `requirements.txt` file. The `requirements.txt` file is just installing the `requirements.txt` file from the other examples directories (like `language-modeling/requirements.txt`). The user can adjust this depending on which example they want to run.

I set up this example to be similar to the way the Intel AI Containers repo is setup with the README being generated using helm-doc, the dockerfile being built using docker-compose, and a `ci` folder with Helm values files for validated configurations.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
